### PR TITLE
Login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Django Firebase authentication
+
+## Setup
+
+## Required settings
+
+* `DJANGO_FIREBASE_AUTH_AUTH_BACKEND` - Django auth backend that Firebase authentication should use. Required.
+* `DJANGO_FIREBASE_AUTH_SERVICE_ACCOUNT_FILE` - Firebase service account file for using Firebase Admin SDK. Required.
+* `DJANGO_FIREBASE_AUTH_WEB_API_KEY` - Firebase app web API key (public-facing). Required.
+
+
+## Using `django_firebase_auth` views
+
+Register `django_firebase_auth` URLs in your project's `urls.py`, e.g.:
+
+```
+urlpatterns = [
+    ...
+    path('firebase_authentication/', include("django_firebase_auth.urls")),
+    ...
+]
+```
+
+If you want Firebase authentication page to be your default login page, configure this in your `settings.py`:
+
+```
+LOGIN_URL = '/firebase_authentication/login`
+```
+
+If you want Firebase SSO login page to have a fallback link to a different login page, set:
+
+```
+DJANGO_FIREBASE_AUTH_FALLBACK_LOGIN_URL = '/your-fallback-login-page'
+```

--- a/README.md
+++ b/README.md
@@ -4,31 +4,24 @@
 
 ## Required settings
 
-* `DJANGO_FIREBASE_AUTH_AUTH_BACKEND` - Django auth backend that Firebase authentication should use. Required.
-* `DJANGO_FIREBASE_AUTH_SERVICE_ACCOUNT_FILE` - Firebase service account file for using Firebase Admin SDK. Required.
-* `DJANGO_FIREBASE_AUTH_WEB_API_KEY` - Firebase app web API key (public-facing). Required.
+* `DJANGO_FIREBASE_AUTH_AUTH_BACKEND` - Django auth backend that Firebase authentication should use.
+* `DJANGO_FIREBASE_AUTH_SERVICE_ACCOUNT_FILE` - Firebase service account file for using Firebase Admin SDK.
+* `DJANGO_FIREBASE_AUTH_WEB_API_KEY` - Firebase app web API key (public-facing).
 
 
 ## Using `django_firebase_auth` views
 
-Register `django_firebase_auth` URLs in your project's `urls.py`, e.g.:
+Register `django_firebase_auth` URLs and `django.contrib.admin.site.urls` in your project's `urls.py`, e.g.:
 
 ```
+from django.contrib import admin
+
 urlpatterns = [
     ...
-    path('firebase_authentication/', include("django_firebase_auth.urls")),
+    path('', include("django_firebase_auth.urls")),
+    ...
+    path('admin/', admin.site.urls),
     ...
 ]
 ```
-
-If you want Firebase authentication page to be your default login page, configure this in your `settings.py`:
-
-```
-LOGIN_URL = '/firebase_authentication/login`
-```
-
-If you want Firebase SSO login page to have a fallback link to a different login page, set:
-
-```
-DJANGO_FIREBASE_AUTH_FALLBACK_LOGIN_URL = '/your-fallback-login-page'
-```
+Make sure to register `admin.site.urls` _after_ `django_firebase_auth` because `django_firebase_auth` uses `/admin/login` URL.

--- a/django_firebase_auth/templates/firebase_authentication/login.html
+++ b/django_firebase_auth/templates/firebase_authentication/login.html
@@ -18,7 +18,7 @@
             document.getElementById("error").style.display = "block";
         }
 
-        function signInWithFirebaseToken(idToken) {
+        function logInWithFirebaseToken(idToken) {
             const init = {
                 headers: { [JWT_HEADER_NAME]: idToken },
                 credentials: "same-origin"
@@ -45,21 +45,21 @@
                 });
         }
 
-        function signInWithFirebaseUser(user) {
+        function logInWithFirebaseUser(user) {
             user.getIdToken()
-                .then(signInWithFirebaseToken)
+                .then(logInWithFirebaseToken)
                 .catch(function (error) {
                     showError("Something went wrong");
                     console.log(error);
                 })
         }
 
-        function signIn() {
+        function logIn() {
             var email = document.getElementById('email').value;
             var password = document.getElementById('password').value;
             app.auth().signInWithEmailAndPassword(email, password)
                 .then(function (userCredential) {
-                    signInWithFirebaseUser(userCredential.user)
+                    logInWithFirebaseUser(userCredential.user)
                 })
                 .catch(function (error) {
                     showError(error.message);
@@ -68,28 +68,36 @@
         }
 
         window.onload = function () {
-            document.getElementById('sign-in-button').addEventListener('click', signIn, false);
+            document
+                .getElementById('login')
+                .addEventListener(
+                    'submit',
+                    function (event) {
+                        event.preventDefault();
+                        logIn();
+                    });
         };
     </script>
 
 </head>
 
 <body>
-    <div id="sign-in">
-        <input type="text" id="email">
-        <br>
-        <input type="password" id="password">
-        <br>
-        <button id="sign-in-button">Sign In</button>
-        <br>
+    <div>
+        <form id="login">
+            Email: <input type="text" id="email">
+            <br>
+            Password: <input type="password" id="password">
+            <br>
+            <input type="submit" value="Sign In">
+        </form>
     </div>
 
     <div id="error" style="display:none"></div>
 
     {% if fallback_login_url %}
-        <div id="fallback-login">
-            <a href="{{ fallback_login_url }}">Sign in using admin panel</a>
-        </div>
+    <div id="fallback-login">
+        <a href="{{ fallback_login_url }}">Sign in without Firebase SSO</a>
+    </div>
     {% endif %}
 </body>
 

--- a/django_firebase_auth/templates/firebase_authentication/login.html
+++ b/django_firebase_auth/templates/firebase_authentication/login.html
@@ -1,0 +1,96 @@
+<html>
+
+<head>
+    <script src="https://www.gstatic.com/firebasejs/9.9.1/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.9.1/firebase-auth-compat.js"></script>
+    <script type="text/javascript">
+
+        const JWT_HEADER_NAME = "{{ jwt_header_name }}";
+        const FIREBASE_AUTH_ENDPOINT = "{{ firebase_auth_endpoint }}";
+        const LOGIN_REDIRECT_URL = "{{ login_redirect_url }}";
+
+        const app = firebase.initializeApp({
+            apiKey: "{{ firebase_web_api_key }}"
+        });
+
+        function showError(message) {
+            document.getElementById("error").textContent = message;
+            document.getElementById("error").style.display = "block";
+        }
+
+        function signInWithFirebaseToken(idToken) {
+            const init = {
+                headers: { [JWT_HEADER_NAME]: idToken },
+                credentials: "same-origin"
+            };
+            fetch(FIREBASE_AUTH_ENDPOINT, init)
+                .then(function (response) {
+                    if (response.status === 200) {
+                        window.location.href = LOGIN_REDIRECT_URL;
+                    } else {
+                        response.json()
+                            .then(function (json) {
+                                showError("Failed to sign in: " + json.description);
+                                console.log(json);
+                            })
+                            .catch(function (error) {
+                                showError("Something went wrong");
+                                console.log(error);
+                            });
+                    }
+                })
+                .catch(function (error) {
+                    showError("Network error");
+                    console.log(error);
+                });
+        }
+
+        function signInWithFirebaseUser(user) {
+            user.getIdToken()
+                .then(signInWithFirebaseToken)
+                .catch(function (error) {
+                    showError("Something went wrong");
+                    console.log(error);
+                })
+        }
+
+        function signIn() {
+            var email = document.getElementById('email').value;
+            var password = document.getElementById('password').value;
+            app.auth().signInWithEmailAndPassword(email, password)
+                .then(function (userCredential) {
+                    signInWithFirebaseUser(userCredential.user)
+                })
+                .catch(function (error) {
+                    showError(error.message);
+                    console.log(error);
+                });
+        }
+
+        window.onload = function () {
+            document.getElementById('sign-in-button').addEventListener('click', signIn, false);
+        };
+    </script>
+
+</head>
+
+<body>
+    <div id="sign-in">
+        <input type="text" id="email">
+        <br>
+        <input type="password" id="password">
+        <br>
+        <button id="sign-in-button">Sign In</button>
+        <br>
+    </div>
+
+    <div id="error" style="display:none"></div>
+
+    {% if fallback_login_url %}
+        <div id="fallback-login">
+            <a href="{{ fallback_login_url }}">Sign in using admin panel</a>
+        </div>
+    {% endif %}
+</body>
+
+</html>

--- a/django_firebase_auth/templates/firebase_authentication/login.html
+++ b/django_firebase_auth/templates/firebase_authentication/login.html
@@ -74,7 +74,12 @@
                     'submit',
                     function (event) {
                         event.preventDefault();
-                        logIn();
+                        if (event.submitter.id === "sign-in-django") {
+                            document.getElementById("next").value = LOGIN_REDIRECT_URL;
+                            document.getElementById("login").submit();
+                        } else {
+                            logIn();
+                        }
                     });
         };
     </script>
@@ -83,21 +88,23 @@
 
 <body>
     <div>
-        <form id="login">
-            Email: <input type="text" id="email">
+        <form id="login" method="POST">
+            {% csrf_token %}
+            Email: <input type="text" id="email" name="email">
             <br>
-            Password: <input type="password" id="password">
+            Password: <input type="password" id="password" name="password">
             <br>
-            <input type="submit" value="Sign In">
+            <input type="hidden" id="next" name="next" >
+            <input type="submit" id="sign-in-firebase" value="Sign in with Firebase user">
+            <br>
+            <input type="submit" id="sign-in-django" value="Sign in with Django user">
         </form>
     </div>
 
+    {% if error %}
+    <div id="error">{{ error }}</div>
+    {% else %}
     <div id="error" style="display:none"></div>
-
-    {% if fallback_login_url %}
-    <div id="fallback-login">
-        <a href="{{ fallback_login_url }}">Sign in without Firebase SSO</a>
-    </div>
     {% endif %}
 </body>
 

--- a/django_firebase_auth/urls.py
+++ b/django_firebase_auth/urls.py
@@ -1,7 +1,8 @@
 from django.urls import re_path
 
-from .views import authenticate
+from .views import authenticate, login_page
 
 urlpatterns = [
-    re_path(r'firebase_authentication/v1/login/?$', authenticate),
+    re_path(r'api/v1/login/?$', authenticate),
+    re_path(r'login/?$', login_page),
 ]

--- a/django_firebase_auth/urls.py
+++ b/django_firebase_auth/urls.py
@@ -1,8 +1,8 @@
 from django.urls import re_path
 
-from .views import authenticate, LoginView
+from .views import authenticate, AdminLoginView
 
 urlpatterns = [
-    re_path(r'api/v1/login/?$', authenticate),
-    re_path(r'login/?$', LoginView.as_view()),
+    re_path(r'firebase_authentication/v1/login/?$', authenticate),
+    re_path(r'admin/login/?$', AdminLoginView.as_view()),
 ]

--- a/django_firebase_auth/urls.py
+++ b/django_firebase_auth/urls.py
@@ -1,8 +1,8 @@
 from django.urls import re_path
 
-from .views import authenticate, login_page
+from .views import authenticate, LoginView
 
 urlpatterns = [
     re_path(r'api/v1/login/?$', authenticate),
-    re_path(r'login/?$', login_page),
+    re_path(r'login/?$', LoginView.as_view()),
 ]

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import AbstractBaseUser
 from django.template import loader
-from django.shortcuts import redirect
+from django.shortcuts import redirect, resolve_url
 from django.urls import reverse
 
 
@@ -107,16 +107,17 @@ def _verify_firebase_account(headers: HttpHeaders) -> str:
 
 
 def login_page(request: HttpRequest) -> HttpResponse:
+    next = request.GET.get('next', resolve_url(settings.LOGIN_REDIRECT_URL))
     if request.user.is_authenticated:
-        return redirect(request.GET.get('next', settings.LOGIN_REDIRECT_URL))
+        return redirect(next)
     template = loader.get_template('firebase_authentication/login.html')
     return HttpResponse(
         template.render({
             'firebase_web_api_key': WEB_API_KEY,
             'jwt_header_name': JWT_HEADER_NAME,
             'firebase_auth_endpoint': reverse(authenticate),
-            'login_redirect_url': settings.LOGIN_REDIRECT_URL,
-            'django_login_url': settings.LOGIN_URL,
-            'fallback_login_url': FALLBACK_LOGIN_URL,
+            'login_redirect_url': next,
+            'django_login_url': resolve_url(settings.LOGIN_URL),
+            'fallback_login_url': resolve_url(FALLBACK_LOGIN_URL),
         })
     )

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -4,17 +4,23 @@ from firebase_admin import credentials, auth, initialize_app
 from firebase_admin.auth import ExpiredIdTokenError
 from firebase_admin.exceptions import FirebaseError
 from django.contrib.auth import get_user_model
-from django.http import HttpRequest, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.http.request import HttpHeaders
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import AbstractBaseUser
+from django.template import loader
+from django.shortcuts import redirect
+from django.urls import reverse
+
 
 AUTH_BACKEND = settings.DJANGO_FIREBASE_AUTH_AUTH_BACKEND
 SERVICE_ACCOUNT_FILE = settings.DJANGO_FIREBASE_AUTH_SERVICE_ACCOUNT_FILE
+WEB_API_KEY = settings.DJANGO_FIREBASE_AUTH_WEB_API_KEY
 JWT_HEADER_NAME = getattr(settings, "DJANGO_FIREBASE_AUTH_JWT_HEADER_NAME", "X-FIREBASE-JWT")
 CREATE_USER_IF_NOT_EXISTS = getattr(settings, "DJANGO_FIREBASE_AUTH_CREATE_USER_IF_NOT_EXISTS", False)
 ALLOW_NOT_CONFIRMED_EMAILS = getattr(settings, "DJANGO_FIREBASE_AUTH_ALLOW_NOT_CONFIRMED_EMAILS", False)
+FALLBACK_LOGIN_URL = getattr(settings, "DJANGO_FIREBASE_AUTH_FALLBACK_LOGIN_URL", None)
 
 firebase_credentials = credentials.Certificate(SERVICE_ACCOUNT_FILE)
 initialize_app(firebase_credentials)
@@ -22,30 +28,36 @@ initialize_app(firebase_credentials)
 
 class AuthError(Exception):
     error_type = 'OTHER'
+    error_description = 'Something went wrong'
 
     @classmethod
     def make_response_body(cls):
-        return {'error': cls.error_type, 'description': ''}
+        return {'error': cls.error_type, 'description': cls.error_description}
 
 
 class NoAuthHeader(AuthError):
     error_type = 'NO_AUTH_HEADER'
+    error_description = 'Missing Firebase authentication header'
 
 
 class JWTExpired(AuthError):
     error_type = 'JWT_EXPIRED'
+    error_description = 'Firebase authentication token is expired'
 
 
 class JWTInvalid(AuthError):
     error_type = 'JWT_INVALID'
+    error_description = 'Firebase authentication token is invalid'
 
 
 class UserNotRegistered(AuthError):
     error_type = 'USER_NOT_REGISTERED'
+    error_description = 'This user has not been registered'
 
 
 class EmailNotVerified(AuthError):
     error_type = 'EMAIL_NOT_VERIFIED'
+    error_description = 'User email has not been verified'
 
 
 def authenticate(request: HttpRequest):
@@ -70,7 +82,7 @@ def _get_or_create_user(email: str) -> Optional[AbstractBaseUser]:
         if not CREATE_USER_IF_NOT_EXISTS:
             return None
 
-    user = UserModel.objects.create_user(email=email, is_active=True)
+    user = UserModel.objects.create_user(username=email, email=email, is_active=True)
     user.set_unusable_password()
     user.save()
     return user
@@ -82,6 +94,7 @@ def _verify_firebase_account(headers: HttpHeaders) -> str:
         raise NoAuthHeader()
     try:
         decoded_token = auth.verify_id_token(jwt)
+        print(decoded_token)
     except ExpiredIdTokenError:
         raise JWTExpired()
     except FirebaseError:
@@ -92,3 +105,19 @@ def _verify_firebase_account(headers: HttpHeaders) -> str:
         raise EmailNotVerified()
 
     return decoded_token['email']
+
+
+def login_page(request: HttpRequest) -> HttpResponse:
+    if request.user.is_authenticated:
+        return redirect(request.GET.get('next', settings.LOGIN_REDIRECT_URL))
+    template = loader.get_template('firebase_authentication/login.html')
+    return HttpResponse(
+        template.render({
+            'firebase_web_api_key': WEB_API_KEY,
+            'jwt_header_name': JWT_HEADER_NAME,
+            'firebase_auth_endpoint': reverse(authenticate),
+            'login_redirect_url': settings.LOGIN_REDIRECT_URL,
+            'django_login_url': settings.LOGIN_URL,
+            'fallback_login_url': FALLBACK_LOGIN_URL,
+        })
+    )

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -165,16 +165,17 @@ class AdminLoginView(View):
             return self._render(request, next, "Password field must be non-empty")
         
         UserModel = get_user_model()
+        user: AbstractBaseUser
         try:
-            user: AbstractBaseUser = UserModel.objects.get(email=email)
-            if user.check_password(password):
-                login(request, user=user, backend=AUTH_BACKEND)
-                if request.user.is_staff:
-                    return redirect(next)
-                else:
-                    return self._non_staff_error(request, next)
-            else:
-                return self._render(request, next, "Wrong password")
-
+            user = UserModel.objects.get(email=email)
         except UserModel.DoesNotExist:
             return self._render(request, next, "Wrong email")
+
+        if user.check_password(password):
+            login(request, user=user, backend=AUTH_BACKEND)
+            if request.user.is_staff:
+                return redirect(next)
+            else:
+                return self._non_staff_error(request, next)
+        else:
+            return self._render(request, next, "Wrong password")

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -82,7 +82,7 @@ def _get_or_create_user(email: str) -> Optional[AbstractBaseUser]:
         if not CREATE_USER_IF_NOT_EXISTS:
             return None
 
-    user = UserModel.objects.create_user(username=email, email=email, is_active=True)
+    user = UserModel.objects.create_user(email=email, is_active=True)
     user.set_unusable_password()
     user.save()
     return user

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -94,7 +94,6 @@ def _verify_firebase_account(headers: HttpHeaders) -> str:
         raise NoAuthHeader()
     try:
         decoded_token = auth.verify_id_token(jwt)
-        print(decoded_token)
     except ExpiredIdTokenError:
         raise JWTExpired()
     except FirebaseError:

--- a/django_firebase_auth/views.py
+++ b/django_firebase_auth/views.py
@@ -170,7 +170,7 @@ class AdminLoginView(View):
             if user.check_password(password):
                 login(request, user=user, backend=AUTH_BACKEND)
                 if request.user.is_staff:
-                    redirect(next)
+                    return redirect(next)
                 else:
                     return self._non_staff_error(request, next)
             else:


### PR DESCRIPTION
This PR implements a login page. The flow is this:

1. Login page shows a simple email and password form.
2. When a user submits the login form, a fetch call is fired to the authentication endpoint.
3. If the authentication call succeeds, the user is redirected either to the URL that was passed on via `?next=` parameter or (if there was no such parameter) to `settings.LOGIN_REDIRECT_URL`.

By default, this in no way interferes with other login mechanisms. You have to change `settings.LOGIN_URL` in order to use this as a default login page.

Since this PR adds a view that is not an JSON API view, I've also changed the URL schema to separate pages from API endpoints. If this doesn't seem right, just let me know.

A note about `DJANGO_FIREBASE_AUTH_FALLBACK_LOGIN_URL` settings parameter. This parameter sets a fallback login URL in case Firebase isn't working. I was thinking of using `settings.LOGIN_URL` for this by default at first, but the problem is that the user of this library may want to use Firebase login page as the `settings.LOGIN_URL` page. This would result in a circular fallback link that just links to itself. It would be possible to check whether Firebase login view is set as `LOGIN_URL` and use `LOGIN_URL` as a fallback only if it's not (using [django.urls.reverse()](https://docs.djangoproject.com/en/4.0/ref/urlresolvers/#reverse)), but I'm not quite sure this is a good idea.