### PR TITLE
Add templates to the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ setup(
     author_email='michal.nowacki@reef.pl',
     license='MIT',
     packages=find_packages(),
+    package_data={'': ['templates/firebase_authentication/*.html']},
+    include_package_data=True,
     python_requires='>=3.6',
     install_requires=["firebase_admin~=5.2.0"],
 )


### PR DESCRIPTION
Originally, when installing this package from `GitHub`, templates were not included in the package.